### PR TITLE
Added ability to create phar-archive

### DIFF
--- a/bin/buildphar
+++ b/bin/buildphar
@@ -1,0 +1,51 @@
+#!/usr/bin/env php
+<?php
+/**
+----------------------------------------------------------------------+
+ *  @desc            Phar-archive builder
+ *  @file            buildphar
+ *  @author          Jóhann T. Maríusson <jtm@hi.is>
+ *  @author          Alexander Yancharuk <alex@itvault.info>
+ *  @copyright
+ *    phplinter is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+----------------------------------------------------------------------+
+ */
+$srcRoot = dirname(dirname(__FILE__));
+$buildRoot = dirname(__FILE__);
+
+$phar = new Phar(
+	$buildRoot . '/phplinter.phar',
+	FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::KEY_AS_FILENAME,
+	'phplinter.phar'
+);
+$phar->buildFromDirectory($srcRoot);
+$phar->setStub('#!/usr/bin/env php
+<?php
+	namespace phplinter;
+
+	\Phar::mapPhar();
+	require "' . $srcRoot . '/phplinter/autoloader.php";
+	require "' . $srcRoot . '/phplinter/constants.php";
+
+	// ini settings
+	ini_set("memory_limit", "512M");
+	set_time_limit (0);
+
+	$cli = new CLI();
+	$cli->process_options($argv, $argc);
+	$cli->lint();
+
+	__HALT_COMPILER();
+?>');


### PR DESCRIPTION
To create phar-archive run this commands:

./bin/buildphar
chmod +x bin/phplinter.phar
mv bin/phplinter.phar /usr/local/bin/phplinter

After this you can use phplinter as binary executable.
